### PR TITLE
Close the fd opened via os.fdopen at the end

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,5 @@ f = os.fdopen(c2pread, "r")
 f.read()  # Returns "Hello world!\n"
 # Clean up the child process.
 os.waitpid(pid, 0)  # Returns (pid, <returncode>)
+f.close()
 ```


### PR DESCRIPTION
If I'm not misstaken we should probably close the file descriptor `f` opened by `os.fdopen`